### PR TITLE
Add notions of computations as monoids

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 - [Data types a la carte](http://www.cs.ru.nl/~W.Swierstra/Publications/DataTypesALaCarte.pdf)
 - [Trees that grow](https://www.microsoft.com/en-us/research/uploads/prod/2016/11/trees-that-grow.pdf)
 - [I am not a Number, I am a Free Variable!](http://www.cs.ru.nl/~james/RESEARCH/haskell2004.pdf)
+- [Notions of Computation as Monoids - Exequiel Rivas, Mauro Jaskelioff https://www.fceia.unr.edu.ar/~mauro/pubs/Notions_of_Computation_as_Monoids_ext.pdf]
 
 #### Algebra of programming
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@
 - [Data types a la carte](http://www.cs.ru.nl/~W.Swierstra/Publications/DataTypesALaCarte.pdf)
 - [Trees that grow](https://www.microsoft.com/en-us/research/uploads/prod/2016/11/trees-that-grow.pdf)
 - [I am not a Number, I am a Free Variable!](http://www.cs.ru.nl/~james/RESEARCH/haskell2004.pdf)
-- [Notions of Computation as Monoids - Exequiel Rivas, Mauro Jaskelioff https://www.fceia.unr.edu.ar/~mauro/pubs/Notions_of_Computation_as_Monoids_ext.pdf]
+- [Notions of Computation as Monoids - Exequiel Rivas, Mauro Jaskelioff](https://www.fceia.unr.edu.ar/~mauro/pubs/Notions_of_Computation_as_Monoids_ext.pdf)
 
 #### Algebra of programming
 


### PR DESCRIPTION
Add Notions of computations as monoids paper - extended edition. It is available from Mauro Jaskelioff (one of the authors) page https://www.fceia.unr.edu.ar/~mauro/ 

It is easy to read and covers many interesting topics like:
- unify difference lists and Codensity monad as Cayley representation
- unify monads, applicatives, arrows as monoids in monoidal category

IMHO would be nice to add this resource here.

Thanks for compiling this list I like the the way publications are separated into sections.